### PR TITLE
Fix: Strip html tags from notification subject

### DIFF
--- a/frappe_comment_xt/overrides/whitelist/comment.py
+++ b/frappe_comment_xt/overrides/whitelist/comment.py
@@ -4,13 +4,10 @@ import frappe
 from frappe.core.doctype.file.utils import extract_images_from_html
 from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification
 from frappe.desk.form.document_follow import follow_document
+from frappe.utils import strip_html_tags
 from frappe.utils.html_utils import clean_email_html
 
-from frappe_comment_xt.helpers.comment import (
-    filter_comments_by_visibility,
-    get_mention_user,
-    get_thread_participants,
-)
+from frappe_comment_xt.helpers.comment import filter_comments_by_visibility, get_mention_user, get_thread_participants
 
 if TYPE_CHECKING:
     from frappe.core.doctype.comment.comment import Comment
@@ -62,7 +59,7 @@ def add_comment_override(
                     "type": "Mention",
                     "document_type": reference_doctype,
                     "document_name": reference_name,
-                    "subject": f"{frappe.bold(comment_by)} replied in thread: {clean_email_html(comment_content)}",
+                    "subject": f"{frappe.bold(comment_by)} replied in thread: {strip_html_tags(clean_email_html(comment_content))}",
                     "from_user": frappe.session.user,
                     "email_content": content,
                 }


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
Fix mangled notification for comment reply if a user is mentioned.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
Strip HTML tags from the comment content.

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->
Check if a user is mentioned in a thread, other (non-mentioned) user notifications are normal and not jumbled.

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->
N/A

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->
Before Fix:
<img width="374" alt="Screenshot 2025-01-29 at 6 53 52 PM" src="https://github.com/user-attachments/assets/11a72f4e-d57f-4b49-9b16-11d50b053ba0" />

After Fix:
<img width="374" alt="Screenshot 2025-01-29 at 8 10 27 PM" src="https://github.com/user-attachments/assets/5a8f0ab6-1d64-4751-af00-1ae916f0a7fc" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
