### PR TITLE
Fix: remove edit-mode css

### DIFF
--- a/frappe_comment_xt/public/css/replies.css
+++ b/frappe_comment_xt/public/css/replies.css
@@ -63,10 +63,6 @@
   }
 }
 
-.edit-mode {
-  display: none;
-}
-
 .reply-container {
   display: block;
   margin-top: 14px;


### PR DESCRIPTION
## Description

Frappe uses `.edit-mode` class for editing shortcuts and connections in home page, so currently using this without a selector interferes with rendering that view.

## Relevant Technical Choices

Technically, we can replace with adding the selector with `.timeline-item .edit-mode` to select `.edit-mode` only within a comment, but have removed it since it is only rendering an empty div.
This is done to avoid adding style to frappe core class.

## Testing Instructions

The change is hosted in ERP Dev site.
1. Test `Edit` is working in home page (https://erp-dev.rt.gw/app/home)
2. Check comment reply functionality is working as expected.

## Additional Information:
N/A

## Screenshot/Screencast

The edit mode custom implemented div is present in the DOM and not set as `display: none`
![Screenshot 2025-02-24 at 5 23 38 PM](https://github.com/user-attachments/assets/7f13bc19-7cee-4318-a3a8-4c1a236dc44b)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
