### PR TITLE
fix: add doctype exists check in get_all_replies

### DIFF
--- a/frappe_comment_xt/overrides/whitelist/comment.py
+++ b/frappe_comment_xt/overrides/whitelist/comment.py
@@ -140,6 +140,10 @@ def get_comment_visibility(name: str):
 @frappe.whitelist()
 def get_all_replies(reference_doctype: str, reference_name: str):
     """Get all replies for a comment in a structured format"""
+
+    if not frappe.db.exists(reference_doctype, reference_name):
+        return {}
+
     frappe.has_permission(reference_doctype, "read", doc=reference_name, throw=True)
 
     replies = frappe.get_all(


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

This pull request makes a small but important change to the `get_all_replies` function to improve its robustness. Now, the function first checks if the referenced document exists before proceeding, and returns an empty dictionary if it does not.

* Added a check in `get_all_replies` to return an empty dictionary if the referenced document does not exist, preventing errors when invalid references are provided. (`frappe_comment_xt/overrides/whitelist/comment.py`)

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
